### PR TITLE
fix: update default model to "openai:o3"

### DIFF
--- a/pretty_release_notes/openai_client.py
+++ b/pretty_release_notes/openai_client.py
@@ -8,7 +8,7 @@ from tenacity import (
 )
 
 DEFAULT_PROVIDER = "openai"
-DEFAULT_MODEL = "openai:gpt-4.1"
+DEFAULT_MODEL = "openai:o3"
 OPENAI_MODELS_WITH_FLEX = {
 	"o3",
 	"o4-mini",

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from pretty_release_notes.openai_client import DEFAULT_MODEL, format_model_name, get_chat_response
+from pretty_release_notes.openai_client import format_model_name, get_chat_response
 
 
 def _mock_completion_response(content: str):
@@ -14,25 +14,6 @@ def _mock_completion_response(content: str):
 
 class TestOpenAIClient:
 	"""Test the compatibility wrapper around any-llm."""
-
-	@patch("pretty_release_notes.openai_client.completion")
-	def test_default_model_is_passed_through_to_any_llm(self, mock_completion):
-		mock_completion.return_value = _mock_completion_response("summary")
-
-		result = get_chat_response(
-			content="Write a summary",
-			model=DEFAULT_MODEL,
-			api_key="test-key",
-		)
-
-		assert result == "summary"
-		mock_completion.assert_called_once_with(
-			messages=[{"role": "user", "content": "Write a summary"}],
-			model=DEFAULT_MODEL,
-			api_key="test-key",
-			client_args={"timeout": 900.0},
-			service_tier="auto",
-		)
 
 	@patch("pretty_release_notes.openai_client.completion")
 	def test_plain_model_defaults_to_openai_provider_for_backward_compatibility(self, mock_completion):


### PR DESCRIPTION
This offers great results at a resonable price (with flex service-tier).
